### PR TITLE
Bugfix/parsing context params

### DIFF
--- a/api/lib/src/request/model/uploader_params.dart
+++ b/api/lib/src/request/model/uploader_params.dart
@@ -322,10 +322,13 @@ class UploadParams extends UploaderParams {
       return null;
     }
     return context.entries.map((map) {
-      if (map.value is List<dynamic>) {
-        _encodeList(map.value);
-      } else if (map.value is String) {
-        _cldEncodeSingleContextItem((map.value as String));
+      final key = map.key;
+      final dynamic value = map.value;
+
+      if (value is List<dynamic>) {
+        return '${key}=${_encodeList(value)}';
+      } else {
+        return '${key}=${_cldEncodeSingleContextItem(value.toString())}';
       }
     }).join('|');
   }

--- a/api/lib/src/response/upload_result.dart
+++ b/api/lib/src/response/upload_result.dart
@@ -202,12 +202,12 @@ class ResultColor {
 }
 
 class ResultContext {
-  Map<String, String>? custom;
+  Map<String, dynamic>? custom;
 
   ResultContext(this.custom);
 
   factory ResultContext.fromJson(Map<String, dynamic> data) {
-    final custom = data['custom'] as Map<String, String>?;
+    final custom = data['custom'] as Map<String, dynamic>?;
     return ResultContext(custom);
   }
 }

--- a/api/test/src/request/model/uploader_params_test.dart
+++ b/api/test/src/request/model/uploader_params_test.dart
@@ -1,0 +1,55 @@
+import 'package:cloudinary_api/src/request/model/uploader_params.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+void main() {
+  group('Context Params', () {
+    test('null context is not included in params map', () {
+      // Given
+      const Map<String, dynamic>? context = null;
+      const expectedParamsMap = <String, dynamic>{};
+
+      // When
+      final uploadParams = UploadParams(context: context);
+      final paramsMap = uploadParams.buildParams();
+
+      // Then
+      expect(paramsMap, expectedParamsMap);
+    });
+
+    test('string context param should be mapped correctly', () {
+      // Given
+      const context = <String, dynamic>{
+        'user': 'id',
+      };
+      const expectedParamsMap = <String, dynamic>{
+        'context': 'user=id',
+      };
+
+      // When
+      final uploadParams = UploadParams(context: context);
+      final paramsMap = uploadParams.buildParams();
+
+      // Then
+      expect(paramsMap, expectedParamsMap);
+    });
+
+    test('multiple context values should be joined', () {
+      // Given
+      const context = <String, dynamic>{
+        'user': 'id',
+        'claimed': false,
+      };
+      const expectedParamsMap = <String, dynamic>{
+        'context': 'user=id|claimed=false',
+      };
+
+      // When
+      final uploadParams = UploadParams(context: context);
+      final paramsMap = uploadParams.buildParams();
+
+      // Then
+      expect(paramsMap, expectedParamsMap);
+    });
+  });
+}


### PR DESCRIPTION
Context parameters were not mapped which which resulted in `null|null` value for `context` parameter.