### PR TITLE
fix(utils): requests with signature missing api_key

### DIFF
--- a/api/lib/uploader/uploader_utils.dart
+++ b/api/lib/uploader/uploader_utils.dart
@@ -47,6 +47,12 @@ class UploaderUtils {
       }
     }
 
+    if (paramsMap['api_key'] == null && (config.apiKey?.isNotEmpty ?? false)) {
+      // Handles the scenario where the signature is specified explicitly.
+      if (paramsMap['signature'] != null) paramsMap['api_key'] = config.apiKey;
+    }
+
+
     var url = [prefix, apiVersion, cloudName, resourceType, action]
         .noNullList()
         .join("/");


### PR DESCRIPTION
### Brief Summary of Changes

Looks like `_requireSigning` only covers the cases when the signature is not provided, but when this signature parameter is provided in `UploadParams` - the request fails with 400 code because of missing API Key (although it already exists in `CloudConfig` (for example via `Cloudinary.fromCloudName(cloudName: 'cloud_name, apiKey: 'API_KEY_PROVIDED')`):
```
"{"error":{"message":"Missing required parameter - api_key"}}"
```

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [ ] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I ran the full test suite before pushing the changes and all the tests pass.
